### PR TITLE
yt-dlp upgrade to 2025.03.26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ Flask~=3.0.2
 croniter==3.0.3
 ffmpeg-python==0.2.0
 youtube-search-python==1.6.6
-yt-dlp~=2024.8.6
+yt-dlp~=2025.03.26
 pydantic==2.9.0


### PR DESCRIPTION
Upgrade `yt-dlp` to mitigate errors, including from: https://github.com/nwithan8/plex-prerolls/issues/18