### PR TITLE
Modules: youtube_downloader: cookies file option for yt-dlp via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ Example of a generated preroll:
 
 <img src="https://raw.githubusercontent.com/nwithan8/plex-prerolls/main/documentation/images/recently-added-preroll-example.png" alt="logo" width="300">
 
+> :warning: This feature requires [extracting cookies for YouTube](https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp) and storing them in a file called `yt_dlp_cookies.txt` alongside your `config.yaml` file.
+
 ##### Setup
 
 [Set up a Plex webhook](https://support.plex.tv/articles/115002267687-webhooks/) to point to the application's

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -140,7 +140,6 @@ monthly:
 advanced:
   auto_generation:
     plex_path: /path/to/auto-generated/prerolls/in/plex # The path for the Plex Media Server to use to access auto-generated prerolls
-    cookies_file: /config/cookies.txt
     recently_added:
       # If enabled, auto-generate prerolls for recently added items and add them as an always-on choice (files will be uploaded to the "Preroll Auto-Generated/Recently Added" folder)
       enabled: true # If enabled, auto-generate prerolls for recently added items and add them to the "always" list

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -140,6 +140,7 @@ monthly:
 advanced:
   auto_generation:
     plex_path: /path/to/auto-generated/prerolls/in/plex # The path for the Plex Media Server to use to access auto-generated prerolls
+    cookies_file: /config/cookies.txt
     recently_added:
       # If enabled, auto-generate prerolls for recently added items and add them as an always-on choice (files will be uploaded to the "Preroll Auto-Generated/Recently Added" folder)
       enabled: true # If enabled, auto-generate prerolls for recently added items and add them to the "always" list

--- a/modules/config_parser.py
+++ b/modules/config_parser.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import List, Union
 
 import confuse
@@ -258,11 +259,12 @@ class AutoGenerationConfig(ConfigSection):
     def local_path_root(self) -> str:
         # The local (internal) path where auto-generated prerolls will be stored
         return AUTO_GENERATED_PREROLLS_DIR
-    
+
     @property
     def cookies_file(self) -> str:
-        return self._get_value(key="cookies_file", default="/config/cookies.txt")
-    
+        cookies_file_path = "/config/yt_dlp_cookies.txt"
+        return cookies_file_path if os.path.exists(cookies_file_path) else ""
+
     @property
     def recently_added(self) -> RecentlyAddedAutoGenerationConfig:
         return RecentlyAddedAutoGenerationConfig(data=self.data, parent=self)

--- a/modules/config_parser.py
+++ b/modules/config_parser.py
@@ -258,7 +258,11 @@ class AutoGenerationConfig(ConfigSection):
     def local_path_root(self) -> str:
         # The local (internal) path where auto-generated prerolls will be stored
         return AUTO_GENERATED_PREROLLS_DIR
-
+    
+    @property
+    def cookies_file(self) -> str:
+        return self._get_value(key="cookies_file", default="/config/cookies.txt")
+    
     @property
     def recently_added(self) -> RecentlyAddedAutoGenerationConfig:
         return RecentlyAddedAutoGenerationConfig(data=self.data, parent=self)

--- a/modules/renderers/recently_added.py
+++ b/modules/renderers/recently_added.py
@@ -64,22 +64,22 @@ class RecentlyAddedPrerollRenderer(PrerollRenderer):
             selector_function=ytd.SelectorPresets.select_first_video,
             results_limit=5)
         video_url = ytd.get_video_url(video_id=video_id)
-        video_file_path = ytd.download_youtube_video(config,
-                                                     url=video_url,
+        video_file_path = ytd.download_youtube_video(url=video_url,
+                                                     config=config,
                                                      output_dir=self.download_folder,
                                                      output_filename=self._video_file_name)
         logging.info("Trailer retrieved successfully")
         return video_file_path
 
-    def _get_background_music(self) -> str:
+    def _get_background_music(self, config: Config) -> str:
         search_query = f"{self.youtube_search_query_movie_title} movie soundtrack"
         logging.info(f'Retrieving background music for "{self.movie_title}", YouTube search query: "{search_query}"')
         video_id = ytd.run_youtube_search(query=f"{self.youtube_search_query_movie_title} movie soundtrack",
                                           selector_function=ytd.SelectorPresets.select_first_video,
                                           results_limit=5)
         video_url = ytd.get_video_url(video_id=video_id)
-        video_file_path = ytd.download_youtube_video(config,
-                                                     url=video_url,
+        video_file_path = ytd.download_youtube_video(url=video_url,
+                                                     config=config,
                                                      output_dir=self.download_folder,
                                                      output_filename=self._audio_file_name)
         logging.info("Background music retrieved successfully")
@@ -113,8 +113,8 @@ class RecentlyAddedPrerollRenderer(PrerollRenderer):
 
         self.download_folder = utils.get_temporary_directory_path(parent_directory=self.download_folder)
         logging.info(f'Retrieving assets for preroll of "{self.movie_title}", saving to {self.download_folder}')
-        video_path = self._get_trailer(config)
-        audio_path = self._get_background_music(config)
+        video_path = self._get_trailer(config=config)
+        audio_path = self._get_background_music(config=config)
         audio_path = _trim_background_music(background_music_file_path=audio_path)
         poster_path = self._get_movie_poster()
 

--- a/modules/renderers/recently_added.py
+++ b/modules/renderers/recently_added.py
@@ -56,7 +56,7 @@ class RecentlyAddedPrerollRenderer(PrerollRenderer):
     def youtube_search_query_movie_title(self) -> str:
         return f'"{self.movie_title}" {self.movie_year or ""}'.strip()
 
-    def _get_trailer(self) -> str:
+    def _get_trailer(self, config: Config) -> str:
         search_query = f"{self.youtube_search_query_movie_title} Official Movie Theatrical Trailer"
         logging.info(f'Retrieving trailer for "{self.movie_title}", YouTube search query: "{search_query}"')
         video_id = ytd.run_youtube_search(
@@ -64,7 +64,8 @@ class RecentlyAddedPrerollRenderer(PrerollRenderer):
             selector_function=ytd.SelectorPresets.select_first_video,
             results_limit=5)
         video_url = ytd.get_video_url(video_id=video_id)
-        video_file_path = ytd.download_youtube_video(url=video_url,
+        video_file_path = ytd.download_youtube_video(config,
+                                                     url=video_url,
                                                      output_dir=self.download_folder,
                                                      output_filename=self._video_file_name)
         logging.info("Trailer retrieved successfully")
@@ -77,7 +78,8 @@ class RecentlyAddedPrerollRenderer(PrerollRenderer):
                                           selector_function=ytd.SelectorPresets.select_first_video,
                                           results_limit=5)
         video_url = ytd.get_video_url(video_id=video_id)
-        video_file_path = ytd.download_youtube_video(url=video_url,
+        video_file_path = ytd.download_youtube_video(config,
+                                                     url=video_url,
                                                      output_dir=self.download_folder,
                                                      output_filename=self._audio_file_name)
         logging.info("Background music retrieved successfully")
@@ -111,8 +113,8 @@ class RecentlyAddedPrerollRenderer(PrerollRenderer):
 
         self.download_folder = utils.get_temporary_directory_path(parent_directory=self.download_folder)
         logging.info(f'Retrieving assets for preroll of "{self.movie_title}", saving to {self.download_folder}')
-        video_path = self._get_trailer()
-        audio_path = self._get_background_music()
+        video_path = self._get_trailer(config)
+        audio_path = self._get_background_music(config)
         audio_path = _trim_background_music(background_music_file_path=audio_path)
         poster_path = self._get_movie_poster()
 

--- a/modules/youtube_downloader.py
+++ b/modules/youtube_downloader.py
@@ -2,6 +2,7 @@ from typing import Callable
 
 import youtubesearchpython
 import yt_dlp
+import os
 
 import modules.logs as logging
 
@@ -106,11 +107,13 @@ def download_youtube_video(url: str, output_dir: str, output_filename: str = Non
     :param output_filename: The output filename.
     :return: The path to the downloaded file.
     """
+    cookies_file = os.getenv('YT_DLP_COOKIES', '/config/cookies.txt')
     options = {
         "paths": {"home": output_dir},
         'logger': YouTubeDownloaderLogger(),
         # 'progress_hooks': [_download_progress_hook],
         "overwrites": True,
+	    'cookiefile': cookies_file,
     }
     if output_filename:
         options['outtmpl'] = f"{output_filename}.%(ext)s"
@@ -131,6 +134,7 @@ def download_youtube_audio(url: str, output_dir: str, output_filename: str = Non
     :param output_filename: The output filename.
     :return: The path to the downloaded file.
     """
+    cookies_file = os.getenv('YT_DLP_COOKIES', '/config/cookies.txt')
     options = {
         "paths": {"home": output_dir},
         'format': 'm4a/bestaudio/best',
@@ -141,6 +145,7 @@ def download_youtube_audio(url: str, output_dir: str, output_filename: str = Non
         'logger': YouTubeDownloaderLogger(),
         # 'progress_hooks': [_download_progress_hook],
         "overwrites": True,
+	    'cookiefile': cookies_file,
     }
     if output_filename:
         options['outtmpl'] = f"{output_filename}.%(ext)s"

--- a/modules/youtube_downloader.py
+++ b/modules/youtube_downloader.py
@@ -5,6 +5,7 @@ import yt_dlp
 import os
 
 import modules.logs as logging
+from modules.config_parser import Config
 
 
 class SelectorPresets:
@@ -98,7 +99,7 @@ def run_youtube_search(query: str, selector_function: Callable[[dict], str], res
     return selector_function(videos)
 
 
-def download_youtube_video(url: str, output_dir: str, output_filename: str = None) -> str:
+def download_youtube_video(config: Config, url: str, output_dir: str, output_filename: str = None) -> str:
     """
     Download a YouTube video as a video file.
 
@@ -107,7 +108,8 @@ def download_youtube_video(url: str, output_dir: str, output_filename: str = Non
     :param output_filename: The output filename.
     :return: The path to the downloaded file.
     """
-    cookies_file = os.getenv('YT_DLP_COOKIES', '/config/cookies.txt')
+    cookies_file = config.advanced.auto_generation.cookies_file
+    logging.debug(f'Using yt-dlp cookies file: {cookies_file}')
     options = {
         "paths": {"home": output_dir},
         'logger': YouTubeDownloaderLogger(),

--- a/modules/youtube_downloader.py
+++ b/modules/youtube_downloader.py
@@ -99,26 +99,27 @@ def run_youtube_search(query: str, selector_function: Callable[[dict], str], res
     return selector_function(videos)
 
 
-def download_youtube_video(config: Config, url: str, output_dir: str, output_filename: str = None) -> str:
+def download_youtube_video(url: str, config: Config, output_dir: str, output_filename: str = None) -> str:
     """
     Download a YouTube video as a video file.
 
     :param url: The YouTube video URL.
+    :param config: The configuration for Plex Prerolls.
     :param output_dir: The output directory.
     :param output_filename: The output filename.
     :return: The path to the downloaded file.
     """
     cookies_file = config.advanced.auto_generation.cookies_file
-    logging.debug(f'Using yt-dlp cookies file: {cookies_file}')
     options = {
         "paths": {"home": output_dir},
         'logger': YouTubeDownloaderLogger(),
         # 'progress_hooks': [_download_progress_hook],
         "overwrites": True,
-	    'cookiefile': cookies_file,
     }
     if output_filename:
         options['outtmpl'] = f"{output_filename}.%(ext)s"
+    if cookies_file:
+        options['cookiefile'] = cookies_file
 
     with yt_dlp.YoutubeDL(params=options) as ydl:
         # download the file and extract info
@@ -127,16 +128,17 @@ def download_youtube_video(config: Config, url: str, output_dir: str, output_fil
         return ydl.prepare_filename(info)
 
 
-def download_youtube_audio(url: str, output_dir: str, output_filename: str = None) -> str:
+def download_youtube_audio(url: str, config: Config, output_dir: str, output_filename: str = None) -> str:
     """
     Download a YouTube video as an audio file.
 
     :param url: The YouTube video URL.
+    :param config: The configuration for Plex Prerolls.
     :param output_dir: The output directory.
     :param output_filename: The output filename.
     :return: The path to the downloaded file.
     """
-    cookies_file = os.getenv('YT_DLP_COOKIES', '/config/cookies.txt')
+    cookies_file = config.advanced.auto_generation.cookies_file
     options = {
         "paths": {"home": output_dir},
         'format': 'm4a/bestaudio/best',
@@ -147,10 +149,11 @@ def download_youtube_audio(url: str, output_dir: str, output_filename: str = Non
         'logger': YouTubeDownloaderLogger(),
         # 'progress_hooks': [_download_progress_hook],
         "overwrites": True,
-	    'cookiefile': cookies_file,
     }
     if output_filename:
         options['outtmpl'] = f"{output_filename}.%(ext)s"
+    if cookies_file:
+        options['cookiefile'] = cookies_file
 
     with yt_dlp.YoutubeDL(params=options) as ydl:
         # download the file and extract info

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ Flask~=3.0.2
 croniter==3.0.3
 ffmpeg-python==0.2.0
 youtube-search-python==1.6.6
-yt-dlp~=2025.03.26
+yt-dlp==2025.3.31
 pydantic==2.9.0


### PR DESCRIPTION
Added a cookies file option for `yt-dlp` via the config to mitigate bot-deterrent errors, such as: https://github.com/nwithan8/plex-prerolls/issues/16

Cookies can be retrieved from extensions such as [Get cookies.txt LOCALLY](https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc).

Some instruction should ideally be added to the README on how to setup cookies.