### PR TITLE
Added Environment Variable to specify Trailer Cutoff Year

### DIFF
--- a/.schema/config.schema.json
+++ b/.schema/config.schema.json
@@ -382,10 +382,23 @@
                   "title": "Recently added count",
                   "description": "The number of recently added media to include as prerolls",
                   "$ref": "#/definitions/positiveInteger"
+                },
+                "trailer_cutoff_year": {
+                  "title": "Trailer cutoff year",
+                  "description": "The year to use as a cutoff for trailers. Default is 1980",
+                  "$ref": "#/definitions/positiveInteger"
                 }
-              }
+              },
+              "required": [
+                "enabled",
+                "count"
+              ]
             }
-          }
+          },
+          "required": [
+            "plex_path",
+            "recently_added"
+          ]
         }
       }
     }

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -143,7 +143,8 @@ advanced:
     recently_added:
       # If enabled, auto-generate prerolls for recently added items and add them as an always-on choice (files will be uploaded to the "Preroll Auto-Generated/Recently Added" folder)
       enabled: true # If enabled, auto-generate prerolls for recently added items and add them to the "always" list
-      count: 2 # The number of most-recently added items to use for auto-generation
+      count: 2 # The number of most-recently added items to use for auto-generation 
+      trailer_cutoff_year: 1980 # Optional: Specify the earliest year for valid trailer searches (Defaults to 1980)
 
 
 

--- a/modules/config_parser.py
+++ b/modules/config_parser.py
@@ -239,14 +239,11 @@ class RecentlyAddedAutoGenerationConfig(ConfigSection):
             paths.append(remote_file)
 
         return paths
-    
+
     @property
     def trailer_cutoff_year(self) -> int:
-        try:
-            return int(self._get_value(key="trailer_cutoff_year", default=1980))
-        except (ValueError, TypeError):
-            logging.warning("Invalid 'trailer_cutoff_year' in config. Falling back to 1980.")
-            return 1980
+        return self._get_value(key="trailer_cutoff_year", default=1980)
+
 
 class AutoGenerationConfig(ConfigSection):
     def __init__(self, data):
@@ -414,6 +411,7 @@ class Config:
             "Advanced - Auto Generation - Remote Path Root": self.advanced.auto_generation.remote_path_root,
             "Advanced - Auto Generation - Recently Added - Enabled": self.advanced.auto_generation.recently_added.enabled,
             "Advanced - Auto Generation - Recently Added - Count": self.advanced.auto_generation.recently_added.count,
+            "Advanced - Auto Generation - Recently Added - Trailer Cutoff Year": self.advanced.auto_generation.recently_added.trailer_cutoff_year,
         }
 
     def log(self) -> str:

--- a/modules/config_parser.py
+++ b/modules/config_parser.py
@@ -239,7 +239,14 @@ class RecentlyAddedAutoGenerationConfig(ConfigSection):
             paths.append(remote_file)
 
         return paths
-
+    
+    @property
+    def trailer_cutoff_year(self) -> int:
+        try:
+            return int(self._get_value(key="trailer_cutoff_year", default=1980))
+        except (ValueError, TypeError):
+            logging.warning("Invalid 'trailer_cutoff_year' in config. Falling back to 1980.")
+            return 1980
 
 class AutoGenerationConfig(ConfigSection):
     def __init__(self, data):

--- a/modules/renderers/base.py
+++ b/modules/renderers/base.py
@@ -1,11 +1,12 @@
 from typing import Callable
 
 from modules import youtube_downloader as ytd
+from modules.config_parser import Config
 
 
 class PrerollRenderer:
     def __init__(self):
         pass
 
-    def render(self):
+    def render(self, config: Config):
         raise NotImplementedError

--- a/modules/renderers/recently_added.py
+++ b/modules/renderers/recently_added.py
@@ -9,6 +9,7 @@ import modules.logs as logging
 from consts import ASSETS_DIR, AUTO_GENERATED_RECENTLY_ADDED_PREROLL_PREFIX
 from modules import youtube_downloader as ytd, utils, ffmpeg_utils
 from modules.renderers.base import PrerollRenderer
+from modules.config_parser import Config
 
 import os
 
@@ -97,18 +98,14 @@ class RecentlyAddedPrerollRenderer(PrerollRenderer):
         logging.info("Poster retrieved successfully")
         return file_path
 
-    def render(self) -> Tuple[Union[str, None], Union[str, None]]:
+    def render(self, config: Config) -> Tuple[Union[str, None], Union[str, None]]:
         if not self.movie_title:
             logging.warning("No movie title available, cannot build preroll")
             return None, None
         if not self.movie_year:
             logging.warning("No movie year available, not going to attempt to build preroll")
             return None, None
-        try:
-            trailer_cutoff_year = int(os.getenv('TRAILER_CUTOFF_YEAR', 1980))
-        except ValueError:
-            logging.warning("Invalid TRAILER_CUTOFF_YEAR; defaulting to 1980")
-            trailer_cutoff_year = 1980
+        trailer_cutoff_year = config.advanced.auto_generation.recently_added.trailer_cutoff_year
         if self.movie_year < trailer_cutoff_year:
             # Finding good trailers automatically for movies older than 1980 is difficult (year is arbitrary)
             logging.warning("Movie is too old, not going to attempt to build preroll")

--- a/modules/renderers/recently_added.py
+++ b/modules/renderers/recently_added.py
@@ -11,8 +11,6 @@ from modules import youtube_downloader as ytd, utils, ffmpeg_utils
 from modules.renderers.base import PrerollRenderer
 from modules.config_parser import Config
 
-import os
-
 LENGTH_SECONDS = 33.5
 
 

--- a/modules/renderers/recently_added.py
+++ b/modules/renderers/recently_added.py
@@ -10,6 +10,8 @@ from consts import ASSETS_DIR, AUTO_GENERATED_RECENTLY_ADDED_PREROLL_PREFIX
 from modules import youtube_downloader as ytd, utils, ffmpeg_utils
 from modules.renderers.base import PrerollRenderer
 
+import os
+
 LENGTH_SECONDS = 33.5
 
 
@@ -102,7 +104,12 @@ class RecentlyAddedPrerollRenderer(PrerollRenderer):
         if not self.movie_year:
             logging.warning("No movie year available, not going to attempt to build preroll")
             return None, None
-        if self.movie_year < 1980:
+        try:
+            trailer_cutoff_year = int(os.getenv('TRAILER_CUTOFF_YEAR', 1980))
+        except ValueError:
+            logging.warning("Invalid TRAILER_CUTOFF_YEAR; defaulting to 1980")
+            trailer_cutoff_year = 1980
+        if self.movie_year < trailer_cutoff_year:
             # Finding good trailers automatically for movies older than 1980 is difficult (year is arbitrary)
             logging.warning("Movie is too old, not going to attempt to build preroll")
             return None, None

--- a/modules/webhooks/webhook_processor.py
+++ b/modules/webhooks/webhook_processor.py
@@ -72,7 +72,7 @@ class WebhookProcessor:
 
         renderer = RecentlyAddedPrerollRenderer(render_folder=output_dir,
                                                 movie=plex_movie)
-        asset_folder, local_file_path = renderer.render()
+        asset_folder, local_file_path = renderer.render(config)
 
         if not local_file_path:  # error has already been logged
             return

--- a/modules/webhooks/webhook_processor.py
+++ b/modules/webhooks/webhook_processor.py
@@ -72,7 +72,7 @@ class WebhookProcessor:
 
         renderer = RecentlyAddedPrerollRenderer(render_folder=output_dir,
                                                 movie=plex_movie)
-        asset_folder, local_file_path = renderer.render(config)
+        asset_folder, local_file_path = renderer.render(config=config)
 
         if not local_file_path:  # error has already been logged
             return


### PR DESCRIPTION
Added Environment Variable (`TRAILER_CUTOFF_YEAR`) to specify when to cutoff attempts to search for trailers by movie release year.

This change was made to try to satisfy: https://github.com/nwithan8/plex-prerolls/issues/22