### PR TITLE
Ignore invalid webhook requests

### DIFF
--- a/modules/webhooks/plex.py
+++ b/modules/webhooks/plex.py
@@ -48,7 +48,7 @@ class Metadata(BaseModel):
     parentRatingKey: Optional[str] = None
     grandparentRatingKey: Optional[str] = None
     guid: Optional[str] = None
-    librarySectionID: int
+    librarySectionID: Optional[int] = None
     type: Optional[str] = None
     title: Optional[str] = None
     year: Optional[int] = None


### PR DESCRIPTION
Simply return 200 if the incoming request does not pass Pydantic validation (data payload is not as expected).

This will avoid Pydantic validation errors when receiving playback webhooks with missing data (e.g. webhook for a cinema trailer does not have a `librarySectionID`).

Also make `librarySectionID` nullable. Technically, this is all we should need for this one bug currently, but skipping bad payloads in the future is also a better guard clause.

Closes #26 